### PR TITLE
Force usage of 32bit Driver

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,10 @@ bootRun {
 }
 
 webdriverBinaries {
-    chromedriver '2.45.0'
+    chromedriver {
+        version = '2.45.0'
+        architecture = 'X86'
+    }
     geckodriver '0.24.0'
 }
 


### PR DESCRIPTION
With old version I received always this error:

FAILURE: Build failed with an exception.
* What went wrong:
Execution failed for task ':configureChromeDriverBinary'.
 com.github.erdi.gradle.webdriver.repository.DriverUrlNotFoundException: Driver url not found for name: "chromedriver", version: "2.45.0", platform: "windows", bit: "64"

Forced build to 32bit ChromeDriver 

Other possibility if Firefox is installed remove the chromedriver completely to force ff usage